### PR TITLE
Split out release creation into seperate workflow

### DIFF
--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -16,9 +16,19 @@ jobs:
       GH_ORG: ${{ secrets.GH_ORG }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
+  create-releases:
+    name: Create releases
+    needs: [create-tags]
+    uses: ./.github/workflows/x-create-releases.yml
+    with:
+      tag: nightly
+    secrets:
+      GH_ORG: ${{ secrets.GH_ORG }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
   keycloak-nodejs-admin:
     name: Keycloak Node.js Admin Client
-    needs: [create-tags]
+    needs: [create-tags, create-releases]
     uses: ./.github/workflows/x-keycloak-nodejs-admin.yml
     with:
       version: 999-SNAPSHOT
@@ -45,7 +55,7 @@ jobs:
 
   keycloak:
     name: Keycloak
-    needs: [create-tags,keycloak-admin-console]
+    needs: [create-tags, create-releases, keycloak-admin-console]
     uses: ./.github/workflows/x-keycloak.yml
     with:
       version: 999-SNAPSHOT
@@ -92,7 +102,7 @@ jobs:
 
   keycloak-documentation:
     name: Keycloak Documentation
-    needs: [create-tags]
+    needs: [create-tags, create-releases]
     uses: ./.github/workflows/x-keycloak-documentation.yml
     with:
       version: 999-SNAPSHOT
@@ -108,6 +118,16 @@ jobs:
     with:
       tag: nightly
       target-branch: nightly
+    secrets:
+      GH_ORG: ${{ secrets.GH_ORG }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+  publish-releases:
+    name: Publish releases
+    needs: [keycloak, keycloak-documentation, keycloak-nodejs-admin]
+    uses: ./.github/workflows/x-publish-releases.yml
+    with:
+      tag: nightly
     secrets:
       GH_ORG: ${{ secrets.GH_ORG }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,20 @@ jobs:
       GH_ORG: ${{ secrets.GH_ORG }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
+  create-releases:
+    name: Create releases
+    needs: [create-tags]
+    uses: ./.github/workflows/x-create-releases.yml
+    with:
+      tag: ${{ github.event.inputs.version }}
+      prerelease: false
+    secrets:
+      GH_ORG: ${{ secrets.GH_ORG }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
   keycloak-nodejs-admin:
     name: Keycloak Node.js Admin Client
-    needs: [create-tags]
+    needs: [create-tags, create-releases]
     uses: ./.github/workflows/x-keycloak-nodejs-admin.yml
     with:
       version: ${{ github.event.inputs.version }}
@@ -52,7 +63,7 @@ jobs:
 
   keycloak:
     name: Keycloak
-    needs: [create-tags,keycloak-admin-console]
+    needs: [create-tags, create-releases, keycloak-admin-console]
     uses: ./.github/workflows/x-keycloak.yml
     with:
       version: ${{ github.event.inputs.version }}
@@ -99,7 +110,7 @@ jobs:
 
   keycloak-documentation:
     name: Keycloak Documentation
-    needs: [create-tags]
+    needs: [create-tags, create-releases]
     uses: ./.github/workflows/x-keycloak-documentation.yml
     with:
       version: ${{ github.event.inputs.version }}
@@ -115,6 +126,16 @@ jobs:
     with:
       tag: ${{ github.event.inputs.version }}
       target-branch: latest
+    secrets:
+      GH_ORG: ${{ secrets.GH_ORG }}
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+  publish-releases:
+    name: Publish releases
+    needs: [keycloak, keycloak-documentation, keycloak-nodejs-admin]
+    uses: ./.github/workflows/x-publish-releases.yml
+    with:
+      tag: ${{ github.event.inputs.version }}
     secrets:
       GH_ORG: ${{ secrets.GH_ORG }}
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/x-create-releases.yml
+++ b/.github/workflows/x-create-releases.yml
@@ -1,0 +1,45 @@
+name: X Create releases
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+      prerelease:
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      GH_ORG:
+        required: true
+      GH_TOKEN:
+        required: true
+jobs:
+  create-releases:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+    strategy:
+      matrix:
+        repository:
+          - keycloak
+          - keycloak-documentation
+          - keycloak-nodejs-admin-client
+    steps:
+      - name: Check if release exists
+        id: release-exists
+        run: >
+          echo ::set-output name=exists::$(
+            if ( gh release view ${{ inputs.tag }} --repo ${{ secrets.GH_ORG }}/${{ matrix.repository }} &> /dev/null ); then
+              echo 'true'
+            else
+              echo 'false'
+            fi
+          )
+
+      - name: Delete existing release
+        if: steps.release-exists.outputs.exists == 'true'
+        run: gh release delete ${{ inputs.tag }} --repo ${{ secrets.GH_ORG }}/${{ matrix.repository }} --yes
+
+      - name: Create a release
+        run: gh release create ${{ inputs.tag }} --repo ${{ secrets.GH_ORG }}/${{ matrix.repository }} --title ${{ inputs.tag }} --draft ${{ inputs.prerelease && '--prerelease' || '' }}

--- a/.github/workflows/x-keycloak-documentation.yml
+++ b/.github/workflows/x-keycloak-documentation.yml
@@ -39,10 +39,4 @@ jobs:
       - name: Upload to GitHub Releases
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          if [ ${{ inputs.tag }} == 'nightly' ]; then
-            gh release view nightly | grep 'asset:' | cut -f 2 | xargs -I '{}' gh release delete-asset nightly '{}' -y
-          else
-            gh release create ${{ inputs.tag }}
-          fi
-          gh release upload ${{ inputs.tag }} ./dist/target/keycloak-documentation-${{ inputs.version }}.zip
+        run: gh release upload ${{ inputs.tag }} ./dist/target/keycloak-documentation-${{ inputs.version }}.zip

--- a/.github/workflows/x-keycloak.yml
+++ b/.github/workflows/x-keycloak.yml
@@ -61,10 +61,4 @@ jobs:
       - name: Upload to GitHub Releases
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          if [ ${{ inputs.tag }} == 'nightly' ]; then
-            gh release view nightly | grep 'asset:' | cut -f 2 | xargs -I '{}' gh release delete-asset nightly '{}' -y
-          else
-            gh release create ${{ inputs.tag }}
-          fi
-          gh release upload ${{ inputs.tag }} ./distribution/downloads/target/${{ inputs.version }}/*
+        run: gh release upload ${{ inputs.tag }} ./distribution/downloads/target/${{ inputs.version }}/*

--- a/.github/workflows/x-publish-releases.yml
+++ b/.github/workflows/x-publish-releases.yml
@@ -1,0 +1,26 @@
+name: X Publish releases
+on:
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+    secrets:
+      GH_ORG:
+        required: true
+      GH_TOKEN:
+        required: true
+jobs:
+  publish-releases:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repository:
+          - keycloak
+          - keycloak-documentation
+          - keycloak-nodejs-admin-client
+    steps:
+      - name: Publish release
+        run: gh release edit ${{ inputs.tag }} --repo ${{ secrets.GH_ORG }}/${{ matrix.repository }} --draft=false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Turns the Github Release into separate workflows with the following steps for for the Admin Client, Keycloak and Documentation:

1. Delete the releases if they already exists under the same tag.
2. Create the Github releases and mark them as drafts (also pre-release if `nightly`).
3. Build and upload artifacts to each release.
4. Convert releases from draft to published once all artifacts have been uploaded.