### PR TITLE
Update release process of keycloak server to not push to quickstarts latest branch

### DIFF
--- a/.github/workflows/announce.yml
+++ b/.github/workflows/announce.yml
@@ -19,6 +19,17 @@ jobs:
   env:
     uses: ./.github/workflows/x-env.yml
 
+  keycloak-quickstarts:
+    name: Keycloak QuickStarts
+    needs: [env]
+    uses: ./.github/workflows/x-keycloak-quickstarts.yml
+    with:
+      gh-org: ${{ needs.env.outputs.gh-org }}
+      server-version: ${{ github.event.inputs.version }}
+      target-branch: main
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
   update-website:
     name: Update website
     uses: ./.github/workflows/x-keycloak-web.yml

--- a/.github/workflows/branch-create.yml
+++ b/.github/workflows/branch-create.yml
@@ -50,7 +50,6 @@ jobs:
         repository:
           - keycloak
           - keycloak-nodejs-connect
-          - keycloak-quickstarts
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/branch-delete.yml
+++ b/.github/workflows/branch-delete.yml
@@ -56,7 +56,6 @@ jobs:
         repository:
           - keycloak
           - keycloak-nodejs-connect
-          - keycloak-quickstarts
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -102,17 +102,6 @@ jobs:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
 
-  keycloak-quickstarts:
-    name: Keycloak QuickStarts
-    needs: [env, create-tags, keycloak]
-    uses: ./.github/workflows/x-keycloak-quickstarts.yml
-    with:
-      gh-org: ${{ needs.env.outputs.gh-org }}
-      tag: nightly
-      target-branch: nightly
-    secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
   publish-gh-releases:
     name: Publish releases
     needs: [env, keycloak, keycloak-nodejs-connect]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,17 +113,6 @@ jobs:
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
 
-  keycloak-quickstarts:
-    name: Keycloak QuickStarts
-    needs: [env, create-tags, keycloak]
-    uses: ./.github/workflows/x-keycloak-quickstarts.yml
-    with:
-      gh-org: ${{ needs.env.outputs.gh-org }}
-      tag: ${{ github.event.inputs.version }}
-      target-branch: latest
-    secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
   publish-gh-releases:
     name: Publish releases
     needs: [env, keycloak, keycloak-nodejs-connect]

--- a/.github/workflows/x-create-tags.yml
+++ b/.github/workflows/x-create-tags.yml
@@ -33,7 +33,6 @@ jobs:
         repository:
           - keycloak
           - keycloak-nodejs-connect
-          - keycloak-quickstarts
 
     steps:
       - name: Checkout repository
@@ -67,5 +66,4 @@ jobs:
     needs: [create-tags]
     steps:
       - run: |
-          echo "https://github.com/${{ inputs.gh-org }}/keycloak/tree/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY
-          echo "https://github.com/${{ inputs.gh-org }}/keycloak-quickstarts/tree/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY
+          echo "https://github.com/${{ inputs.gh-org }}/keycloak/tree/${{ inputs.tag }}  " >> $GITHUB_STEP_SUMMARY          

--- a/.github/workflows/x-keycloak-quickstarts.yml
+++ b/.github/workflows/x-keycloak-quickstarts.yml
@@ -6,7 +6,7 @@ on:
       gh-org:
         required: true
         type: string
-      tag:
+      server-version:
         required: true
         type: string
       target-branch:
@@ -30,12 +30,17 @@ jobs:
         with:
           repository: '${{ inputs.gh-org }}/keycloak-quickstarts'
           token: ${{ secrets.GH_TOKEN }}
-          ref: ${{ inputs.tag }}
+          ref: ${{ inputs.target-branch }}
 
-      - name: Update branch
+      - name: Set server version
         run: |
-          git switch -C ${{ inputs.target-branch }}
-          git push --force origin refs/heads/${{ inputs.target-branch }}
+          ./set-server-version.sh ${{ inputs.server-version }}
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git commit -a -m "Set server version to ${{ inputs.server-version }}"          
+
+      - name: Push changes
+        run: git push origin ${{ inputs.target-branch }}
 
       - name: Show QuickStart branch
-        run: echo "https://github.com/${{ inputs.gh-org }}/keycloak-quickstarts/tree/${{ inputs.quickstarts-target-branch }}  " >> $GITHUB_STEP_SUMMARY
+        run: echo "https://github.com/${{ inputs.gh-org }}/keycloak-quickstarts/tree/${{ inputs.target-branch }}  " >> $GITHUB_STEP_SUMMARY

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The reason for this is to be able to sandbox the release from the regular day to
 
 In addition there is a fork of the above repository that is used for testing purposes:
 
-* [Keycloak release testing repository](https://github.com/keycloak-rel-testing/keycloak-rel-testing)
+* [Keycloak release testing repository](https://github.com/keycloak-rel-testing/keycloak-rel)
 
 The testing fork allows testing releases without affecting regular releases as it uses different credentials and repositories.
 


### PR DESCRIPTION
closes keycloak/keycloak#35437

During the keycloak server release:

- The new server version is pushed directly to the `main` branch. The commit changing the version updates all the relevant places and looks similar like this: https://github.com/mposolda/keycloak-quickstarts/commit/71221f58125f90c294b94612e841610f40a3700d
- There is no tag created in the quickstarts. Also there is nothing pushed anymore to the branch `latest`

During the keycloak server nightly release:
- The `nightly` tag is still created for quickstarts (so people can download stuff in the ZIP file). The `nightly` branch is not created (it looks that branch is not used for anything)

### Testing

- Did `release` run and `nightly release` run. Both failed during release of keycloak server when building `keycloak/keycloak` (Maybe lack of permissions for maven?). But at least generating of tags work as expected (Tag generated only for `nightly` release) . Runs here:
https://github.com/keycloak-rel-testing/keycloak-rel/actions/runs/12180923014
https://github.com/keycloak-rel-testing/keycloak-rel/actions/runs/12181021270


- Tried to manually run `X Keycloak Quickstarts` in my own fork and it worked OK https://github.com/mposolda/keycloak-rel/actions/runs/12178709565 . It pushed the commit to my quickstart branch for this commit https://github.com/mposolda/keycloak-quickstarts/commit/71221f58125f90c294b94612e841610f40a3700d
